### PR TITLE
Linter errors fixes 

### DIFF
--- a/pkg/cmd/destroy.go
+++ b/pkg/cmd/destroy.go
@@ -27,7 +27,10 @@ var destroyCmd = &cobra.Command{
 		switch resource {
 		case "registry":
 			if profile.LocalRegistry != nil {
-				local_registry.DestroyLocalRegistry()
+				err := local_registry.DestroyLocalRegistry()
+				if err != nil {
+					log.Fatalf("❌ Error destroying local registry: %v", err)
+				}
 				profile.LocalRegistry = nil
 				saveProfile(profile, profilePath)
 				fmt.Println("✅ Registry destroyed successfully")
@@ -35,7 +38,10 @@ var destroyCmd = &cobra.Command{
 
 		case "tunnel":
 			if profile.Tunnel != nil {
-				ngrok.DestroyTunnel()
+				err := ngrok.DestroyTunnel()
+				if err != nil {
+					log.Fatalf("❌ Error destroying tunnel: %v", err)
+				}
 				profile.Tunnel = nil
 				saveProfile(profile, profilePath)
 				fmt.Println("✅ Tunnel destroyed successfully")
@@ -66,14 +72,20 @@ func init() {
 // destroyAllResources destroys all resources defined in the profile.
 func destroyAllResources(profile *parser.Profile, profilePath string) {
 	if profile.LocalRegistry != nil {
-		local_registry.DestroyLocalRegistry()
+		err := local_registry.DestroyLocalRegistry()
+		if err != nil {
+			log.Fatalf("❌ Error destroying local registry: %v", err)
+		}
 		profile.LocalRegistry = nil
 		saveProfile(profile, profilePath)
 		fmt.Println("✅ Registry destroyed successfully")
 	}
 
 	if profile.Tunnel != nil {
-		ngrok.DestroyTunnel()
+		err := ngrok.DestroyTunnel()
+		if err != nil {
+			log.Fatalf("❌ Error destroying tunnel: %v", err)
+		}
 		profile.Tunnel = nil
 		saveProfile(profile, profilePath)
 		fmt.Println("✅ Tunnel destroyed successfully")

--- a/pkg/cmd/registry.go
+++ b/pkg/cmd/registry.go
@@ -41,7 +41,7 @@ var registryCmd = &cobra.Command{
 		if err := local_registry.InitCommand(configFilePath); err != nil {
 			err := ngrok.DestroyTunnel()
 			if err != nil {
-				log.Fatalf("❌ error destroying tunnel: %v. \nYou need to do this manualy", err)
+				log.Fatalf("❌ error destroying tunnel: %v. \nYou need to do this manually", err)
 			}
 			log.Fatalf("❌ error running registry: %v", err)
 		}

--- a/pkg/local_registry/logs.go
+++ b/pkg/local_registry/logs.go
@@ -50,8 +50,7 @@ func PrintLog(rd io.Reader) error {
 			continue // skip invalid json
 		}
 		if lg := strings.Trim(GetNonNilFields(logString), "\n"); lg != "" {
-			log.Printf(lg)
-
+			log.Print(lg)
 		}
 	}
 

--- a/pkg/local_registry/registry.go
+++ b/pkg/local_registry/registry.go
@@ -51,7 +51,7 @@ func runRegistry(dockerClient *client.Client, ctx context.Context, config *parse
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
-				getNetworkId(dockerClient, config.Tunnel.Provider.Ngrok.NetworkName): {}, // connect container to ngrok network os it can be tunneled
+				getNetworkID(dockerClient, config.Tunnel.Provider.Ngrok.NetworkName): {}, // connect container to ngrok network os it can be tunneled
 			},
 		},
 		nil,
@@ -89,7 +89,7 @@ func errorCleanup(containerID string, err *error) {
 	if errDestroy := DestroyLocalRegistry(); errDestroy != nil {
 		cleanupErr := StopAndRemoveContainer(containerID)
 		if cleanupErr != nil {
-			log.Fatalf("❌ Failed to remove container: %v. You will need to do this manualy", cleanupErr)
+			log.Fatalf("❌ Failed to remove container: %v. You will need to do this manually", cleanupErr)
 		}
 	}
 }
@@ -122,7 +122,7 @@ func RotateCommand(configFilePath string) error {
 	return RotateCreds(cli, ctx, config.Registry.Username, config.Registry.Password, config.Registry.Name)
 }
 
-func getNetworkId(dockerClient *client.Client, networkName string) string {
+func getNetworkID(dockerClient *client.Client, networkName string) string {
 	// retrieve network ID that was created for ngrok tunnel if it exists
 	resp, err := dockerClient.NetworkList(
 		context.Background(),

--- a/pkg/local_registry/registry_test.go
+++ b/pkg/local_registry/registry_test.go
@@ -177,5 +177,4 @@ func TestContainerErrorCleanUp(t *testing.T) {
 	} else {
 		t.Fatalf("❌ container still exists after cleanup")
 	}
-
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -61,7 +61,7 @@ type Config struct {
 					Name          string `mapstructure:"name" default:"locreg-container"`
 					OsType        string `mapstructure:"osType" default:"Linux"`
 					RestartPolicy string `mapstructure:"restartPolicy" default:"Always"`
-					IpAddress     struct {
+					IPAddress     struct {
 						Type  string     `mapstructure:"type" default:"Public"`
 						Ports []struct { // should be set to default dynamically because it is a slice of structs
 							Port     int    `mapstructure:"port"`
@@ -70,7 +70,7 @@ type Config struct {
 					} `mapstructure:"ipAddress"`
 					Resources struct {
 						Requests struct {
-							Cpu    float64 `mapstructure:"cpu" default:"1.0"`
+							CPU    float64 `mapstructure:"cpu" default:"1.0"`
 							Memory float64 `mapstructure:"memory" default:"1.5"`
 						} `mapstructure:"requests"`
 					} `mapstructure:"resources"`
@@ -86,7 +86,7 @@ func LoadConfig(filePath string) (*Config, error) {
 	viper.SetConfigType("yaml")
 
 	if err := viper.ReadInConfig(); err != nil {
-		return nil, fmt.Errorf("❌ error reading config file: %v", err)
+		return nil, fmt.Errorf("❌ error reading config file: %w", err)
 	}
 
 	setDynamicDefaults()
@@ -94,7 +94,7 @@ func LoadConfig(filePath string) (*Config, error) {
 
 	var config Config
 	if err := viper.Unmarshal(&config); err != nil {
-		return nil, fmt.Errorf("❌ error unmarshaling config file: %v", err)
+		return nil, fmt.Errorf("❌ error unmarshaling config file: %w", err)
 	}
 
 	if config.Tags == nil {
@@ -176,11 +176,6 @@ func getGitSHA() string {
 	cmd := exec.Command("git", "rev-parse", "HEAD")
 	output, err := cmd.Output()
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.ExitCode() == 128 {
-				return "latest"
-			}
-		}
 		return "latest"
 	}
 	return strings.TrimSpace(string(output))

--- a/pkg/providers/azure/azure_test.go
+++ b/pkg/providers/azure/azure_test.go
@@ -25,6 +25,7 @@ func getProjectRoot() string {
 	dir = filepath.Join(dir, "..", "..", "..")
 	return dir
 }
+
 func generateRandomString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 	var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -112,11 +113,9 @@ func TestDeployAppService(t *testing.T) {
 			log.Println("Web App ID:", *appService.ID)
 		}
 	})
-
 }
 
 func TestDeployContainerInstance(t *testing.T) {
-
 	config, err := parser.LoadConfig(filepath.Join(getProjectRoot(), "test", "test_configs", "azure", "locreg_aci.yaml"))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
@@ -157,11 +156,9 @@ func TestDeployContainerInstance(t *testing.T) {
 			log.Println("ACI created:", *aci.ID)
 		}
 	})
-
 }
 
 func TestCleanupResources(t *testing.T) {
-
 	// Test cleanup function independently
 	ctx := context.Background()
 

--- a/pkg/providers/azure/deploy_aci.go
+++ b/pkg/providers/azure/deploy_aci.go
@@ -13,7 +13,6 @@ import (
 
 // DeployACI handles the deployment of an Azure Container Instance
 func DeployACI(ctx context.Context, azureConfig *parser.Config, tunnelURL string, envVars map[string]string) {
-
 	subscriptionID, err := getSubscriptionID()
 	if err != nil {
 		log.Fatal(err)
@@ -75,12 +74,12 @@ func createACI(ctx context.Context, azureConfig *parser.Config, tunnelURL string
 						Image: to.Ptr(fmt.Sprintf("%s/%s:%s", tunnelURL, imageConfig.Name, imageConfig.Tag)),
 						Ports: []*armcontainerinstance.ContainerPort{
 							{
-								Port: to.Ptr(int32(containerConfig.IpAddress.Ports[0].Port)),
+								Port: to.Ptr(int32(containerConfig.IPAddress.Ports[0].Port)),
 							},
 						},
 						Resources: &armcontainerinstance.ResourceRequirements{
 							Requests: &armcontainerinstance.ResourceRequests{
-								CPU:        to.Ptr[float64](containerConfig.Resources.Requests.Cpu),
+								CPU:        to.Ptr[float64](containerConfig.Resources.Requests.CPU),
 								MemoryInGB: to.Ptr[float64](containerConfig.Resources.Requests.Memory),
 							},
 						},
@@ -91,11 +90,11 @@ func createACI(ctx context.Context, azureConfig *parser.Config, tunnelURL string
 			OSType:        to.Ptr(armcontainerinstance.OperatingSystemTypes(containerConfig.OsType)),
 			RestartPolicy: to.Ptr(armcontainerinstance.ContainerGroupRestartPolicy(containerConfig.RestartPolicy)),
 			IPAddress: &armcontainerinstance.IPAddress{
-				Type: to.Ptr(armcontainerinstance.ContainerGroupIPAddressType(containerConfig.IpAddress.Type)),
+				Type: to.Ptr(armcontainerinstance.ContainerGroupIPAddressType(containerConfig.IPAddress.Type)),
 				Ports: []*armcontainerinstance.Port{
 					{
-						Port:     to.Ptr(int32(containerConfig.IpAddress.Ports[0].Port)),
-						Protocol: to.Ptr(armcontainerinstance.ContainerGroupNetworkProtocol(containerConfig.IpAddress.Ports[0].Protocol)),
+						Port:     to.Ptr(int32(containerConfig.IPAddress.Ports[0].Port)),
+						Protocol: to.Ptr(armcontainerinstance.ContainerGroupNetworkProtocol(containerConfig.IPAddress.Ports[0].Protocol)),
 					},
 				},
 			},

--- a/pkg/providers/azure/deploy_app_service.go
+++ b/pkg/providers/azure/deploy_app_service.go
@@ -14,7 +14,6 @@ import (
 
 // DeployAppService handles the deployment of an Azure App Service
 func DeployAppService(ctx context.Context, azureConfig *parser.Config, tunnelURL string, envVars map[string]string) {
-
 	subscriptionID, err := getSubscriptionID()
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/providers/azure/destroy.go
+++ b/pkg/providers/azure/destroy.go
@@ -96,7 +96,6 @@ func Destroy() {
 				log.Println("✅ Resource group deleted:", profile.CloudResource.ContainerInstance.ResourceGroupName)
 			}
 		}
-
 	}
 }
 

--- a/pkg/tunnels/ngrok/destroy.go
+++ b/pkg/tunnels/ngrok/destroy.go
@@ -23,7 +23,6 @@ func DestroyTunnel() error {
 	err = local_registry.StopAndRemoveContainer(profile.Tunnel.ContainerID)
 	if err != nil {
 		return fmt.Errorf("❌ failed to stop or remove tunnel container: %w", err)
-
 	}
 	log.Printf("❌ Tunnel container with container ID %s terminated", profile.Tunnel.ContainerID)
 

--- a/pkg/tunnels/ngrok/tunnel.go
+++ b/pkg/tunnels/ngrok/tunnel.go
@@ -53,8 +53,8 @@ func RunNgrokTunnelContainer(config *parser.Config) {
 		},
 	}
 
-	networkId := getNetworkId(dockerClient, config.Tunnel.Provider.Ngrok.NetworkName)
-	if networkId == "" {
+	networkID := getNetworkID(dockerClient, config.Tunnel.Provider.Ngrok.NetworkName)
+	if networkID == "" {
 		netResp, err := dockerClient.NetworkCreate(
 			context.Background(),
 			config.Tunnel.Provider.Ngrok.NetworkName,
@@ -63,7 +63,7 @@ func RunNgrokTunnelContainer(config *parser.Config) {
 		if err != nil {
 			log.Fatalf("❌ failed to create network: %v", err)
 		}
-		networkId = netResp.ID
+		networkID = netResp.ID
 	}
 	// Create container
 	imagePuller, err := dockerClient.ImagePull(ctx, containerImage, image.PullOptions{})
@@ -95,7 +95,7 @@ func RunNgrokTunnelContainer(config *parser.Config) {
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
-				networkId: {},
+				networkID: {},
 			},
 		},
 		nil,
@@ -116,7 +116,7 @@ func RunNgrokTunnelContainer(config *parser.Config) {
 }
 
 // writeToProfile writes the container ID and credentials to the profile file in TOML format
-func writeToProfile(dockerId string, port string) error {
+func writeToProfile(dockerID string, port string) error {
 	var tunnelsResponse Tunnels
 	var resp *http.Response
 	profilePath, err := parser.GetProfilePath()
@@ -138,11 +138,11 @@ func writeToProfile(dockerId string, port string) error {
 	}
 	err = json.NewDecoder(resp.Body).Decode(&tunnelsResponse)
 	if err != nil {
-		return fmt.Errorf("❌ failed to decode response body: %v", err)
+		return fmt.Errorf("❌ failed to decode response body: %w", err)
 	}
 	// write to profile
 	profile.Tunnel = &parser.Tunnel{
-		ContainerID: dockerId,
+		ContainerID: dockerID,
 		URL:         tunnelsResponse.Tunnels[0].PublicURL,
 	}
 	if err := parser.SaveProfile(profile, profilePath); err != nil {
@@ -151,7 +151,7 @@ func writeToProfile(dockerId string, port string) error {
 	return nil
 }
 
-func getNetworkId(dockerClient *client.Client, networkName string) string {
+func getNetworkID(dockerClient *client.Client, networkName string) string {
 	resp, err := dockerClient.NetworkList(
 		context.Background(),
 		network.ListOptions{

--- a/test/locreg_testutils/containers.go
+++ b/test/locreg_testutils/containers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+
 	"testing"
 )
 


### PR DESCRIPTION
All fixed errors:
```
pkg/cmd/destroy.go:30:40: Error return value of `local_registry.DestroyLocalRegistry` is not checked (errcheck)
                                local_registry.DestroyLocalRegistry()
                                                                   ^
pkg/cmd/destroy.go:38:24: Error return value of `ngrok.DestroyTunnel` is not checked (errcheck)
                                ngrok.DestroyTunnel()
                                                   ^
pkg/cmd/destroy.go:69:38: Error return value of `local_registry.DestroyLocalRegistry` is not checked (errcheck)
                local_registry.DestroyLocalRegistry()
                                                   ^
pkg/cmd/destroy.go:76:22: Error return value of `ngrok.DestroyTunnel` is not checked (errcheck)
                ngrok.DestroyTunnel()
                                   ^
pkg/providers/azure/deploy.go:60:24: Error return value is not checked (errcheck)
        checkTunnelURLValidity(tunnelURL)
                              ^
pkg/tunnels/ngrok/tunnel_test.go:39:15: Error return value of `http.Serve` is not checked (errcheck)
        go http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
                     ^
pkg/local_registry/registry_config.go:60:6: comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
                if err == io.EOF {
                   ^
pkg/parser/parser.go:179:23: type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
                if exitError, ok := err.(*exec.ExitError); ok {
                                    ^
pkg/parser/parser.go:89:63: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                return nil, fmt.Errorf("❌ error reading config file: %v", err)
                                                                            ^
pkg/local_registry/registry_config.go:69:59: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                                return fmt.Errorf("❌ error reading config.yml: %v", err)
                                                                                      ^
pkg/local_registry/registry_config.go:64:56: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                        return fmt.Errorf("❌ error reading tar file: %v", err)
                                                                            ^
pkg/providers/azure/deploy.go:152:16: G107: Potential HTTP request made with variable url (gosec)
                resp, err := http.Get(checkURL)
                             ^
pkg/local_registry/registry_config.go:75:19: ineffectual assignment to err (ineffassign)
        configTarBuffer, err := prepareTar(string(yamlBytes)+configUpdates, "config.yml")
                         ^
pkg/local_registry/registry_config.go:136:18: ineffectual assignment to err (ineffassign)
        credsTarBuffer, err := prepareTar(
                        ^
pkg/cmd/registry.go:44:72: `manualy` is a misspelling of `manually` (misspell)
                                log.Fatalf("❌ error destroying tunnel: %v. \nYou need to do this manualy", err)
                                                                                                   ^
pkg/local_registry/registry.go:92:77: `manualy` is a misspelling of `manually` (misspell)
                        log.Fatalf("❌ Failed to remove container: %v. You will need to do this manualy", cleanupErr)
                                                                                                 ^
pkg/tunnels/ngrok/tunnel_test.go:121:60: `beeing` is a misspelling of `being` (misspell)
                t.Fatalf("❌ NGROK_AUTHTOKEN is not being validated for beeing empty")
                                                                         ^
pkg/local_registry/logs.go:53:4: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
                        log.Printf(lg)
                        ^
pkg/local_registry/registry_test.go:181:1: unnecessary trailing newline (whitespace)

^
pkg/tunnels/ngrok/tunnel_test.go:30:35: unnecessary leading newline (whitespace)

^
pkg/providers/azure/deploy_aci.go:15:111: unnecessary leading newline (whitespace)

^
pkg/providers/azure/deploy_app_service.go:16:118: unnecessary leading newline (whitespace)

^
pkg/local_registry/registry_config.go:142:1: unnecessary trailing newline (whitespace)

^
pkg/local_registry/logs.go:55:3: unnecessary trailing newline (whitespace)

^
24 issues:
* errcheck: 6
* errorlint: 5
* gosec: 1
* ineffassign: 2
* misspell: 3
* staticcheck: 1
* whitespace: 6
```
Default tests ware run 